### PR TITLE
Creating HelperCode for Json files

### DIFF
--- a/WebPulse/HelperCode.cs
+++ b/WebPulse/HelperCode.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WebPulse
+{
+    public class HelperCode
+    {
+        public string GetJsonLocation()
+        {
+            return string.Join("\\", Directory.GetCurrentDirectory(), "SetupJson.json");
+        }
+    }
+}

--- a/WebPulse/MainWindow.xaml.cs
+++ b/WebPulse/MainWindow.xaml.cs
@@ -28,8 +28,12 @@ namespace WebPulse
 
         private BrowserFetcher _browserFetcher;
 
+        private HelperCode helperCode;
+
         public MainWindow()
         {
+            this.helperCode = new HelperCode();
+
             InitializeComponent();
             MainContent.Content = new Home();
  
@@ -118,7 +122,7 @@ namespace WebPulse
 
         private async Task Monitoring_loop()
         {
-            string path = "C:\\Users\\ahme1636\\OneDrive - Syddansk Erhvervsskole\\Dokumenter\\Webpulse\\WebPulse\\json\\SetupJson.json";
+            string path = helperCode.GetJsonLocation();
             if (File.Exists(path))
             {
                 string existingJson = File.ReadAllText(path);

--- a/WebPulse/Monitor.xaml.cs
+++ b/WebPulse/Monitor.xaml.cs
@@ -14,10 +14,13 @@ namespace WebPulse
 {
     public partial class Monitor : UserControl
     {
+        private readonly HelperCode helperCode;
         Dictionary<string, string> setupConfigItems = new Dictionary<string, string>();
 
         public Monitor()
         {
+            this.helperCode = new HelperCode();
+
             InitializeComponent();
             UpdateList();
         }
@@ -122,7 +125,7 @@ namespace WebPulse
         {
             try
             {
-                string path = "C:\\Users\\ahme1636\\OneDrive - Syddansk Erhvervsskole\\Dokumenter\\Webpulse\\WebPulse\\json\\SetupJson.json";
+                string path = helperCode.GetJsonLocation();
                 Debug.WriteLine("File path: " + path);
 
                 string directory = System.IO.Path.GetDirectoryName(path);
@@ -183,7 +186,7 @@ namespace WebPulse
         {
             try
             {
-                string path = "C:\\Users\\ahme1636\\OneDrive - Syddansk Erhvervsskole\\Dokumenter\\Webpulse\\WebPulse\\jsonn\\SetupJson.json";
+                string path = helperCode.GetJsonLocation();
 
                 if (File.Exists(path))
                 {

--- a/WebPulse/WebPulse.csproj
+++ b/WebPulse/WebPulse.csproj
@@ -122,6 +122,7 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="HelperCode.cs" />
     <Compile Include="Settings.xaml.cs">
       <DependentUpon>Settings.xaml</DependentUpon>
     </Compile>


### PR DESCRIPTION
Changes
Created a helper file for getting the JSON location path.

I also made it relative, and the JSON file now lives where the .exe got executed from.

The smart thing about having helper code for something like getting data from a file, is that if you ever want to change the name of the file, you only need to change it one place, and the rest of the code will change with it.

Note that for the helper code to work, you need to initialize it at the start of the class 😄 

https://github.com/Mech654/WebPulse/blob/c0b3e7cc43684e19b8ace4a2098967dc41b72433/WebPulse/MainWindow.xaml.cs#L31-L35

![image](https://github.com/user-attachments/assets/ee5e2cbd-e3ab-4ecc-a6e2-843ff0b5fd57)
